### PR TITLE
Added curseforge upload task and LLibrary update checker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /build
 /.gradle
 /eclipse
+
+secret.properties

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 *.iml
 *.ipr
 *.iws
-/output
+out/
 
 #ForgeGradle
-/build
-/.gradle
-/eclipse
+build/
+.gradle/
+run/
 
 secret.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,31 @@
 buildscript {
-
     repositories {
-
         mavenCentral()
-
         maven {
-
             name = "forge"
             url = "http://files.minecraftforge.net/maven"
         }
-
         maven {
-
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
     }
-
     dependencies {
-
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath "net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT"
+		classpath "com.matthewprenger:CurseGradle:1.0.3-SNAPSHOT"
     }
 }
 
-apply plugin: 'forge'
+apply plugin: "forge"
+apply plugin: "com.matthewprenger.cursegradle"
 
 version = "1.1"
 group = "net.darkhax.bookshelf"
 archivesBaseName = "Bookshelf"
 
 minecraft {
-
     version = "1.7.10-10.13.4.1517-1.7.10"
-    runDir = "eclipse"
+    runDir = "run"
 }
 
 task buildInfo() {
@@ -52,7 +45,11 @@ task buildInfo() {
     }
 }
 
-ext.artifact_version = 'NFG'
+import groovy.json.JsonSlurper
+ext.versionFile = file "versions.json"
+project.ext.versions = new JsonSlurper().parseText versionFile.text
+
+ext.artifact_version = "NFG"
 if (System.getenv().ARTIFACT_VERSION == null) {
     artifact_version = "${version}.${project.buildInfo.buildNum}"
 }
@@ -68,18 +65,18 @@ processResources {
     inputs.property "mcversion", project.minecraft.version
 
     from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-        expand 'version': project.artifact_version, 'mcversion': project.minecraft.version
+        include "mcmod.info"
+        expand "version": project.artifact_version, "mcversion": project.minecraft.version
     }
 
     from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
+        exclude "mcmod.info"
     }
 }
 
 task deobfJar(type: Jar) {
     from sourceSets.main.output
-    classifier = 'deobf'
+    classifier = "deobf"
 }
 
 artifacts {
@@ -96,7 +93,34 @@ uploadArchives {
 
 jar {
     manifest {
+        attributes "FMLCorePlugin": "net.darkhax.bookshelf.asm.BookshelfLoadingPlugin", "FMLCorePluginContainsFMLMod": "true"
+    }
+}
 
-        attributes 'FMLCorePlugin': 'net.darkhax.bookshelf.asm.BookshelfLoadingPlugin', 'FMLCorePluginContainsFMLMod': 'true'
+curseforge {
+    secretFile = file "secret.properties"
+    secretFile.withReader {
+        def prop = new Properties()
+        prop.load(it)
+        secret = new ConfigSlurper().parse prop
+    }
+
+    apiKey = secret.curseForgeApiKey
+
+    project {
+        id = secret.projectId
+    
+        releaseType = "release"
+        changelog = versions.versions[versions.newestVersion].join("\n")
+
+        addGameVersion "1.7.10"
+        
+        mainArtifact(jar) {
+            displayName = "Bookshelf ${artifact_version} for Minecraft 1.7.10"
+        }
+        
+        addArtifact(deobfJar) {
+            displayName = "Bookshelf ${artifact_version} for Minecraft 1.7.10 (Deobf)"
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath "net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT"
-		classpath "com.matthewprenger:CurseGradle:1.0.3-SNAPSHOT"
+        classpath "com.matthewprenger:CurseGradle:1.0.3-SNAPSHOT"
     }
 }
 

--- a/src/main/java/net/darkhax/bookshelf/client/ProxyClient.java
+++ b/src/main/java/net/darkhax/bookshelf/client/ProxyClient.java
@@ -11,6 +11,7 @@ public class ProxyClient extends ProxyCommon {
     @Override
     public void preInit () {
         
+        super.preInit();
         MinecraftForge.EVENT_BUS.register(new RenderingHandler());
         Utilities.currentBlockDamage = ReflectionHelper.findField(PlayerControllerMP.class, "g", "field_78770_f", "curBlockDamageMP");
     }

--- a/src/main/java/net/darkhax/bookshelf/common/ProxyCommon.java
+++ b/src/main/java/net/darkhax/bookshelf/common/ProxyCommon.java
@@ -7,7 +7,7 @@ public class ProxyCommon {
      * exclusively on the client or server side during the pre-initialization phase.
      */
     public void preInit () {
-    
+        FMLInterModComms.sendMessage("llibrary", "update-checker", "https://github.com/Darkhax-Minecraft/Bookshelf/raw/version/versions.json");
     }
     
     /**

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,27 @@
+{
+    "newestVersion": "1.1",
+    "versions":
+    {
+        "1.0.15":
+        [
+            "Added support for horse armor"
+            "Added support for recoloring items"
+            "Added support for disabled gui slots"
+            "Added a Position object"
+            "Added a Tuple object"
+            "Added constants for all Vanilla Colors"
+            "Added tools for working with ASM and byte code"
+            "Added a large amount of utilities for things such as breaking blocks in an area of effect"
+        ],
+        "1.1":
+        [
+            "Fixed issue where ASM code wasn't enabled"
+            "Fixed issue where mcp mappings were being used instead of srg"
+            "Added ItemEnchantedEvent"
+            "Added new color command"
+            "Cleaned up several areas of the code, should give very minor performance increases"
+        ]
+    },
+    "updateUrl": "http://minecraft.curseforge.com/projects/bookshelf/files",
+    "iconUrl": "http://media-elerium.cursecdn.com/avatars/thumbnails/15/169/62/62/635617078813942671.png"
+}


### PR DESCRIPTION
To get the curseforge task to work, make a new file called secret.properties.
In that fire you put two properties, the 'curseForgeApiKey' and the 'projectId'.

Create a new api key on the curseforge website, and use it for the curseForgeApiKey property.
Set the projectId to.. well... the project id.

Make sure not to commit this file, everyone can upload files to your curseforge page with that key!

It generates the changelog from the 'versions.json' file. LLibrary also uses this file to check for updates.

I also changed the minecraft folder to 'run', just because Forge changed that a while ago too.

PS: I didn't test any of it, but it *should* work!