### PR TITLE
Updated version file for LLibrary 0.5.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,7 @@
 {  
     "iconUrl":"http://media-elerium.cursecdn.com/avatars/thumbnails/15/169/62/62/635617078813942671.png",
     "newestVersion":"1.0.2.56",
+    "release":"1.0.2.56",
     "updateUrl":"http://minecraft.curseforge.com/projects/bookshelf/files",
     "versions":{  
         "1.0.2.56":[


### PR DESCRIPTION
LLibrary 0.5.0 changed the version file layout a bit. It now has 3 release types, "release", "beta" and "alpha".
"newestVersion" still works though, and not removed because of backwards compatibility.
You might want to tweak the build file a bit to use the new field.