### PR TITLE
changed supporter url

### DIFF
--- a/src/main/java/net/darkhax/bookshelf/handler/SupporterHandler.java
+++ b/src/main/java/net/darkhax/bookshelf/handler/SupporterHandler.java
@@ -29,7 +29,7 @@ public final class SupporterHandler {
 
     private static final List<SupporterData> supporterData = new ArrayList<>();
 
-    private static final String supporterLocation = "https://raw.githubusercontent.com/Darkhax-Minecraft/Bookshelf/master/supporters.json";
+    private static final String supporterLocation = "https://raw.githubusercontent.com/Darkhax-Minecraft/Bookshelf/1.10.2/supporters.json";
 
     /**
      * Utility classes, such as this one, are not meant to be instantiated. Java adds an


### PR DESCRIPTION
Changed the supporter url. Got this error:

`[Server thread/ERROR] [Bookshelf]: Could not access supporter data.
java.io.FileNotFoundException: https://raw.githubusercontent.com/Darkhax-Minecraft/Bookshelf/master/supporters.json`

See here also:
https://forum.feed-the-beast.com/threads/skyfactory-3-404-for-bookshelf.281919/