### PR TITLE
Updated Polish translation

### DIFF
--- a/src/main/resources/assets/bookshelf/lang/pl_pl.json
+++ b/src/main/resources/assets/bookshelf/lang/pl_pl.json
@@ -32,5 +32,8 @@
     "time.bookshelf.day.wednesday": "Środa",
     "time.bookshelf.day.thursday": "Czwartek",
     "time.bookshelf.day.friday": "Piątek",
-    "time.bookshelf.day.saturday": "Sobota"
+    "time.bookshelf.day.saturday": "Sobota",
+
+    "_comment": "Commands",
+    "commands.bookshelf.loot_tables": "Znaleziono następującą liczbę brakujących tabel łupów: %d dla moda %s."
 }


### PR DESCRIPTION
In this commit I added and translated the new string in the 1.14.4 branch.

Due to the fact that in Polish language in this case we have 1 singular + 2 plural forms and this mod has only one sentence for all 3 of them, I had to develop a workaround and as a result I placed "%s" before "%d". Now the entire sentence in Polish is grammatically correct and covers all 3 cases, but I don't know whether I broke something by swapping these operators.

For the reason above I'm marking this PR as a draft, for now.