### PR TITLE
ItemTier Initialization

### DIFF
--- a/src/main/java/net/darkhax/bookshelf/item/ItemTier.java
+++ b/src/main/java/net/darkhax/bookshelf/item/ItemTier.java
@@ -8,6 +8,7 @@
 package net.darkhax.bookshelf.item;
 
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import net.darkhax.bookshelf.util.RecipeUtils;
 import net.minecraft.item.IItemTier;
@@ -15,6 +16,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.tags.Tag;
+import net.minecraftforge.common.util.Lazy;
 
 /**
  * A basic implementation of IItemTier.
@@ -49,24 +51,64 @@ public class ItemTier implements IItemTier {
     /**
      * A supplier used to check if an item can repair other items of this tier.
      */
-    private final Supplier<Ingredient> repairSupplier;
+    private final Lazy<Ingredient> repairSupplier;
     
+    @SuppressWarnings("unchecked")
+	@SafeVarargs
+    public static ItemTier createFromTags(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Supplier<Tag<Item>>... repairItems) {
+        
+        return new ItemTier(maxUses, efficiency, damage, harvestLevel, enchantability, () -> RecipeUtils.ingredientFromTags(Stream.of(repairItems).map(Supplier::get).toArray(Tag[]::new)));
+    }
+    
+    public static ItemTier createFromTag(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Supplier<Tag<Item>> repairItems) {
+        
+    	return new ItemTier(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromTag(repairItems.get()));
+    }
+    
+    @SafeVarargs
+	public static ItemTier createFromItem(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Supplier<Item>... repairItems) {
+        
+    	return new ItemTier(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromItems(Stream.of(repairItems).map(Supplier::get).toArray(Item[]::new)));
+    }
+    
+    @SafeVarargs
+	public static ItemTier createFromStack(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Supplier<ItemStack>... repairItems) {
+        
+    	return new ItemTier(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromStacks(Stream.of(repairItems).map(Supplier::get).toArray(ItemStack[]::new)));
+    }
+    
+    /**
+     * Use {@link ItemTier#createFromTags(int, float, float, int, int, Supplier)} instead.
+     */
+    @Deprecated
     @SafeVarargs
     public ItemTier(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Tag<Item>... repairItems) {
         
         this(maxUses, efficiency, damage, harvestLevel, enchantability, () -> RecipeUtils.ingredientFromTags(repairItems));
     }
     
+    /**
+     * Use {@link ItemTier#createFromTag(int, float, float, int, int, Supplier)} instead.
+     */
+    @Deprecated
     public ItemTier(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Tag<Item> repairItems) {
         
         this(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromTag(repairItems));
     }
     
+    /**
+     * Use {@link ItemTier#createFromItem(int, float, float, int, int, Supplier)} instead.
+     */
+    @Deprecated
     public ItemTier(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, Item... repairItems) {
         
         this(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromItems(repairItems));
     }
     
+    /**
+     * Use {@link ItemTier#createFromItemStack(int, float, float, int, int, Supplier)} instead.
+     */
+    @Deprecated
     public ItemTier(int maxUses, float efficiency, float damage, int harvestLevel, int enchantability, ItemStack... repairItems) {
         
         this(maxUses, efficiency, damage, harvestLevel, enchantability, () -> Ingredient.fromStacks(repairItems));
@@ -79,7 +121,7 @@ public class ItemTier implements IItemTier {
         this.damage = damage;
         this.harvestLevel = harvestLevel;
         this.enchantability = enchantability;
-        this.repairSupplier = repairItems;
+        this.repairSupplier = Lazy.of(repairItems);
     }
     
     @Override


### PR DESCRIPTION
This a simple fix around registry execution for item tiers. Since an `ItemTier` would most likely be declared in a static final field, there needs to be extra care taken on the inputted ingredient parameters to make sure that they are not loaded until the registry has finished. To counteract this, static final initializer methods were used to add suppliers to all available constructors. The original constructors are deprecated as they should be removed during the next api break. All the fields are now properly deferred until first access.

There would be an issue of tags not being loaded yet. However, the only access provided to the ingredient is within `RecipeContainer`, so there should be no issue in basic implementation.

Also, to save on resources and not construct the supplier output over and over, a Lazy was used to make the supplier deterministic and save the first access.